### PR TITLE
[問屋 - ログイン] ログイン #9

### DIFF
--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -37,11 +37,11 @@ const sessionOptions = {
     pool: pool,
     tableName: "session",
   }),
-  secret: "mysecret",
-  resave: false,
-  saveUninitialized: false,
-  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 },
-  createTableIfMissing: true,
+  secret: "mysecret", //署名付きcookieの秘密鍵
+  resave: false, //セッションが変更されていない場合でも保存するかどうか
+  saveUninitialized: false, //セッションが初期化されていない場合でも保存するかどうか
+  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000, secure: false, httpOnly: true }, // secure: trueにするとhttpsでないとcookieが送信されない、httpOnly: trueにすると外部の悪質なJavaScriptからcookieがアクセスできなくなる
+  createTableIfMissing: true, //sessionテーブルが存在しない場合に自動作成するオプション
 };
 
 //現状のままだとセッション時にCompanyとUserで競合が発生するため注意

--- a/express/src/routes/api.ts
+++ b/express/src/routes/api.ts
@@ -9,6 +9,7 @@ router.get("/hello", (req: Request, res: Response) => {
 });
 
 router.get("/mycompany", (req, res) => {
+  // console.log(req.isAuthenticated());
   if (!req.isAuthenticated()) {
     res.status(401).json({ message: "認証に失敗しました" });
   }

--- a/next.js/src/app/CompanyLoginPage/components/auth/CompanyLoginForm.tsx
+++ b/next.js/src/app/CompanyLoginPage/components/auth/CompanyLoginForm.tsx
@@ -17,6 +17,7 @@ function SigninForm() {
     try {
       const response = await fetch("http://localhost:3001/auth/company/login", {
         method: "POST",
+        credentials: "include", //クロスオリジンであってもcookieをリクエストと一緒に送る場合に必須
         headers: {
           "Content-Type": "application/json",
         },

--- a/next.js/src/app/CompanySignupPage/components/auth/CompanySignupForm.tsx
+++ b/next.js/src/app/CompanySignupPage/components/auth/CompanySignupForm.tsx
@@ -24,6 +24,7 @@ function CompanySignupForm() {
         "http://localhost:3001/auth/company/signup",
         {
           method: "POST",
+          credentials: "include", //クロスオリジンであってもcookieをリクエストと一緒に送る場合に必須
           headers: {
             "Content-Type": "application/json",
           },

--- a/next.js/src/app/MyCompanyPage/page.tsx
+++ b/next.js/src/app/MyCompanyPage/page.tsx
@@ -10,7 +10,7 @@ export default function MyCompanyPage() {
       try {
         const res = await fetch("http://localhost:3001/api/mycompany", {
           method: "GET",
-          credentials: "include",
+          credentials: "include", //cookieデータをつけて送る
         });
         const data = await res.json();
         setMyCompany(data.name);


### PR DESCRIPTION
#9 [問屋 - ログイン] ログイン

## 📝 概要 / What

---

- 問屋側のログイン機能作成

---

## 🔍 変更内容 / Changes

- バックエンド
┗ログイン用のエンドポイントを設定

- フロントエンド
┗ログイン画面を作成
┗ログイン後にマイページに画面遷移（必要な挙動かと思い実装）
┗マイページでcompany_nameを表示　（sessionデータから情報取得できるかの確認したかった）

---

## 💬 補足 / Notes
※簡単ですが記載します

①サインアップ
- http://localhost:3000/CompanySignupPageでユーザー追加
-  マイページ画面に遷移（登録した企業IDを表示）

②ログイン
- http://localhost:3000/CompanyLoginPageでログイン
-  マイページ画面に遷移（登録した企業IDを表示）