### PR TITLE
[問屋 - ログイン] ログアウト#10

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@
    http://localhost:3001
    ```
 
----
-
 ### PostgreSQL の構築手順
 
 #### Docker を使用した簡単な構築方法
@@ -92,10 +90,22 @@
    docker-compose up -d
    ```
 4. PostgreSQL が起動していることを確認します:
+
    ```bash
    docker ps
    ```
+
    `my_portfolio_db` コンテナがリストに表示されていれば成功です。
+
+5. サーバを停止します:
+
+   ```bash
+   docker-compose down
+   ```
+
+   `my_portfolio_db` コンテナがリストに表示されていないことを確認して下さい。
+
+---
 
 #### 手動で構築する場合
 

--- a/express/db/init.sql
+++ b/express/db/init.sql
@@ -1,7 +1,5 @@
 set client_encoding = 'UTF8';
 
-DROP TABLE IF EXISTS companies;
-
 CREATE TABLE IF NOT EXISTS companies (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL UNIQUE,

--- a/express/db/init.sql
+++ b/express/db/init.sql
@@ -1,5 +1,7 @@
 set client_encoding = 'UTF8';
 
+DROP TABLE IF EXISTS companies;
+
 CREATE TABLE IF NOT EXISTS companies (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL UNIQUE,

--- a/express/docker-compose.yml
+++ b/express/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   pgsql_db:
     build: .

--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -37,11 +37,11 @@ const sessionOptions = {
     pool: pool,
     tableName: "session",
   }),
-  secret: "mysecret",
-  resave: false,
-  saveUninitialized: false,
-  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 },
-  createTableIfMissing: true,
+  secret: "mysecret", //署名付きcookieの秘密鍵
+  resave: false, //セッションが変更されていない場合でも保存するかどうか
+  saveUninitialized: false, //セッションが初期化されていない場合でも保存するかどうか
+  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000, secure: false, httpOnly: true }, // secure: trueにするとhttpsでないとcookieが送信されない、httpOnly: trueにすると外部の悪質なJavaScriptからcookieがアクセスできなくなる
+  createTableIfMissing: true, //sessionテーブルが存在しない場合に自動作成するオプション
 };
 
 //現状のままだとセッション時にCompanyとUserで競合が発生するため注意

--- a/express/src/routes/api.ts
+++ b/express/src/routes/api.ts
@@ -9,6 +9,7 @@ router.get("/hello", (req: Request, res: Response) => {
 });
 
 router.get("/mycompany", (req, res) => {
+  // console.log(req.isAuthenticated());
   if (!req.isAuthenticated()) {
     res.status(401).json({ message: "認証に失敗しました" });
   }

--- a/express/src/routes/auth.ts
+++ b/express/src/routes/auth.ts
@@ -38,6 +38,25 @@ router.post("/company/login", (req: Request, res: Response, next: NextFunction) 
   })(req, res, next);
 });
 
+router.get("/company/logout", (req: Request, res: Response, next: NextFunction) => {
+  req.logout((err) => {
+    if (err) {
+      return next(err);
+    }
+    req.session.destroy((err) => {
+      if (err) {
+        return next(err);
+      }
+      res.clearCookie("connect.sid", {
+        path: "/",
+        httpOnly: true, //jsから悪意を持ってcookieを取得するのを防ぐために必要
+        secure: false, // HTTPSで通信があった際に実行する ※本番環境では true にする必要がある
+      });
+      res.status(200).json({ message: "ログアウトしました" });
+    });
+  });
+});
+
 //user用サインアップ機能のため、一旦影響が出ないよう対象外
 // router.post("/signup", AuthController.signup);
 

--- a/next.js/src/app/CompanyLoginPage/components/auth/CompanyLoginForm.tsx
+++ b/next.js/src/app/CompanyLoginPage/components/auth/CompanyLoginForm.tsx
@@ -69,7 +69,7 @@ function SigninForm() {
           required
         />
       </div>
-      <button type="submit">登録</button>
+      <button type="submit">ログイン</button>
     </form>
   );
 }

--- a/next.js/src/app/CompanyLoginPage/components/auth/CompanyLoginForm.tsx
+++ b/next.js/src/app/CompanyLoginPage/components/auth/CompanyLoginForm.tsx
@@ -17,6 +17,7 @@ function SigninForm() {
     try {
       const response = await fetch("http://localhost:3001/auth/company/login", {
         method: "POST",
+        credentials: "include", //クロスオリジンであってもcookieをリクエストと一緒に送る場合に必須
         headers: {
           "Content-Type": "application/json",
         },

--- a/next.js/src/app/CompanySignupPage/components/auth/CompanySignupForm.tsx
+++ b/next.js/src/app/CompanySignupPage/components/auth/CompanySignupForm.tsx
@@ -24,6 +24,7 @@ function CompanySignupForm() {
         "http://localhost:3001/auth/company/signup",
         {
           method: "POST",
+          credentials: "include", //クロスオリジンであってもcookieをリクエストと一緒に送る場合に必須
           headers: {
             "Content-Type": "application/json",
           },

--- a/next.js/src/app/MyCompanyPage/page.tsx
+++ b/next.js/src/app/MyCompanyPage/page.tsx
@@ -10,7 +10,7 @@ export default function MyCompanyPage() {
       try {
         const res = await fetch("http://localhost:3001/api/mycompany", {
           method: "GET",
-          credentials: "include",
+          credentials: "include", //cookieデータをつけて送る
         });
         const data = await res.json();
         setMyCompany(data.name);

--- a/next.js/src/app/MyCompanyPage/page.tsx
+++ b/next.js/src/app/MyCompanyPage/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 export default function MyCompanyPage() {
+  const router = useRouter();
   const [myCompany, setMyCompany] = useState("");
 
   useEffect(() => {
@@ -14,17 +16,34 @@ export default function MyCompanyPage() {
         });
         const data = await res.json();
         setMyCompany(data.name);
-      } catch (e) {
-        console.error("[MycompanyPage]myCompanyデータ取得エラー");
+      } catch (err) {
+        console.error("[MycompanyPage]myCompanyデータ取得エラー", err);
       }
     };
     fetchMycompany();
   }, []);
 
+  const handleClickLogout = async () => {
+    try {
+      const res = await fetch("http://localhost:3001/auth/company/logout", {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        return console.error("[MyCompanyPage]ログアウト失敗");
+      }
+      router.push("/CompanyLoginPage");
+    } catch (err) {
+      console.error("[MyCompanyPage]通信エラー", err);
+    }
+  };
+
   return (
     <>
       <h1>登録済み画面(販売企業様)</h1>
-      <a>ようこそ、{myCompany}様</a>
+      <div>ようこそ、{myCompany}様</div>
+      <button onClick={handleClickLogout}>ログアウト</button>
+      <div>{}</div>
     </>
   );
 }

--- a/next.js/src/app/MyCompanyPage/page.tsx
+++ b/next.js/src/app/MyCompanyPage/page.tsx
@@ -43,7 +43,6 @@ export default function MyCompanyPage() {
       <h1>登録済み画面(販売企業様)</h1>
       <div>ようこそ、{myCompany}様</div>
       <button onClick={handleClickLogout}>ログアウト</button>
-      <div>{}</div>
     </>
   );
 }


### PR DESCRIPTION
#10 [問屋 - ログイン] ログアウト

## 📝 概要 / What

---

- 問屋側のログアウト機能作成

---

## 🔍 変更内容 / Changes

- バックエンド
┗ログアウト用のエンドポイント作成

- フロントエンド
┗マイページ（CompanyMyPage）にログアウトボタン作成
┗ログアウト後にログイン画面に遷移

---

## 💬 補足 / Notes
※簡単ですが記載します

①ログイン
- http://localhost:3000/CompanyLoginPageでログイン
┗サンプルユーザー→　企業ID:test 　PW:test
-  マイページ画面に遷移（登録した企業IDを表示）

②ログアウト
- マイページにてボタン(ログアウト)押下でログインページに遷移
